### PR TITLE
Add clickable lightbox to all portfolio project images

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,18 @@
         <!-- Tabletop Vault -->
         <article class="project-card">
           <div class="project-image">
-            <img src="assets/img/ttv/browse-games.png" alt="Tabletop Vault - Browse games page showing board game cards with prices and ratings">
+            <button class="gallery-trigger" data-gallery="ttv" aria-label="View screenshot">
+              <img src="assets/img/ttv/browse-games.png" alt="Tabletop Vault - Browse games page showing board game cards with prices and ratings">
+              <div class="image-overlay">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M15 3h6v6"></path>
+                  <path d="M9 21H3v-6"></path>
+                  <path d="M21 3l-7 7"></path>
+                  <path d="M3 21l7-7"></path>
+                </svg>
+                <span>View Image</span>
+              </div>
+            </button>
           </div>
           <div class="project-content">
             <h3 class="project-title">Tabletop Vault</h3>
@@ -244,7 +255,18 @@
         <!-- Dice Roll Statistics -->
         <article class="project-card">
           <div class="project-image">
-            <img src="assets/img/dice/stats-gen.png" alt="Dice Roll Statistics - Probability distribution chart comparing 3d6, 4d6n3, and 4d4 dice rolls">
+            <button class="gallery-trigger" data-gallery="dice" aria-label="View screenshot">
+              <img src="assets/img/dice/stats-gen.png" alt="Dice Roll Statistics - Probability distribution chart comparing 3d6, 4d6n3, and 4d4 dice rolls">
+              <div class="image-overlay">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M15 3h6v6"></path>
+                  <path d="M9 21H3v-6"></path>
+                  <path d="M21 3l-7 7"></path>
+                  <path d="M3 21l7-7"></path>
+                </svg>
+                <span>View Image</span>
+              </div>
+            </button>
           </div>
           <div class="project-content">
             <h3 class="project-title">Dice Roll Statistics</h3>
@@ -276,7 +298,18 @@
         <!-- Campaign Mapper -->
         <article class="project-card">
           <div class="project-image">
-            <img src="assets/img/cmap/map-with-hex-overview.png" alt="Campaign Mapper - Hex map editor showing terrain, settlements, and detail panel">
+            <button class="gallery-trigger" data-gallery="cmap" aria-label="View screenshot">
+              <img src="assets/img/cmap/map-with-hex-overview.png" alt="Campaign Mapper - Hex map editor showing terrain, settlements, and detail panel">
+              <div class="image-overlay">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M15 3h6v6"></path>
+                  <path d="M9 21H3v-6"></path>
+                  <path d="M21 3l-7 7"></path>
+                  <path d="M3 21l7-7"></path>
+                </svg>
+                <span>View Image</span>
+              </div>
+            </button>
           </div>
           <div class="project-content">
             <h3 class="project-title">Campaign Mapper</h3>
@@ -307,7 +340,18 @@
         <!-- Shadowdark Encounter Timer -->
         <article class="project-card">
           <div class="project-image">
-            <img src="assets/img/set/timer-config.png" alt="Shadowdark Encounter Timer - Foundry VTT module showing countdown timer and configuration settings">
+            <button class="gallery-trigger" data-gallery="set" aria-label="View screenshot">
+              <img src="assets/img/set/timer-config.png" alt="Shadowdark Encounter Timer - Foundry VTT module showing countdown timer and configuration settings">
+              <div class="image-overlay">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M15 3h6v6"></path>
+                  <path d="M9 21H3v-6"></path>
+                  <path d="M21 3l-7 7"></path>
+                  <path d="M3 21l7-7"></path>
+                </svg>
+                <span>View Image</span>
+              </div>
+            </button>
           </div>
           <div class="project-content">
             <h3 class="project-title">Shadowdark Encounter Timer</h3>
@@ -338,7 +382,18 @@
         <!-- Shadowdark Custom Coins -->
         <article class="project-card">
           <div class="project-image">
-            <img src="assets/img/scc/coin-config.png" alt="Shadowdark Custom Coins - Foundry VTT module showing coin configuration interface">
+            <button class="gallery-trigger" data-gallery="scc" aria-label="View screenshot">
+              <img src="assets/img/scc/coin-config.png" alt="Shadowdark Custom Coins - Foundry VTT module showing coin configuration interface">
+              <div class="image-overlay">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M15 3h6v6"></path>
+                  <path d="M9 21H3v-6"></path>
+                  <path d="M21 3l-7 7"></path>
+                  <path d="M3 21l7-7"></path>
+                </svg>
+                <span>View Image</span>
+              </div>
+            </button>
           </div>
           <div class="project-content">
             <h3 class="project-title">Shadowdark Custom Coins</h3>
@@ -378,6 +433,46 @@
             { "src": "assets/img/siren/map-hexgrid.png", "alt": "Hex grid aggregation view with species density" },
             { "src": "assets/img/siren/resource-table.png", "alt": "Resource table showing species data and occurrence counts" },
             { "src": "assets/img/siren/occurrence-data.png", "alt": "Occurrence data table with species observations" }
+          ]
+        }
+      </script>
+      <script type="application/json" id="gallery-data-ttv">
+        {
+          "title": "Tabletop Vault",
+          "images": [
+            { "src": "assets/img/ttv/browse-games.png", "alt": "Browse games page showing board game cards with prices and ratings" }
+          ]
+        }
+      </script>
+      <script type="application/json" id="gallery-data-dice">
+        {
+          "title": "Dice Roll Statistics",
+          "images": [
+            { "src": "assets/img/dice/stats-gen.png", "alt": "Probability distribution chart comparing 3d6, 4d6n3, and 4d4 dice rolls" }
+          ]
+        }
+      </script>
+      <script type="application/json" id="gallery-data-cmap">
+        {
+          "title": "Campaign Mapper",
+          "images": [
+            { "src": "assets/img/cmap/map-with-hex-overview.png", "alt": "Hex map editor showing terrain, settlements, and detail panel" }
+          ]
+        }
+      </script>
+      <script type="application/json" id="gallery-data-set">
+        {
+          "title": "Shadowdark Encounter Timer",
+          "images": [
+            { "src": "assets/img/set/timer-config.png", "alt": "Foundry VTT module showing countdown timer and configuration settings" }
+          ]
+        }
+      </script>
+      <script type="application/json" id="gallery-data-scc">
+        {
+          "title": "Shadowdark Custom Coins",
+          "images": [
+            { "src": "assets/img/scc/coin-config.png", "alt": "Foundry VTT module showing coin configuration interface" }
           ]
         }
       </script>


### PR DESCRIPTION
- Wrap project thumbnails in gallery-trigger buttons with hover overlay
- Add JSON gallery data blocks for ttv, dice, cmap, set, scc
- Reuse existing lightbox JS for single-image display